### PR TITLE
Added primitive dim template; Removed std::vector where appropriate; Removed unused options;

### DIFF
--- a/src/MCL/BVHTree.cpp
+++ b/src/MCL/BVHTree.cpp
@@ -247,8 +247,9 @@ void BVHTree<T,DIM,PDIM>::collide(
     assert((left.second == right.second) ? (left.first != right.first) : true);
 
     // Check if nodes intersect or inactive
-    if (!boxes_intersect(left,right))
+    if (!boxes_intersect(left,right)) {
         return;
+    }
 
     // Both are leaf nodes
     if (left.second && right.second)
@@ -275,11 +276,11 @@ void BVHTree<T,DIM,PDIM>::collide(
 
         if (options.discrete)
         {
-            int p0[DIM], p1[DIM];
-            for (int i=0; i<DIM; ++i)
+            int p0[PDIM], p1[PDIM];
+            for (int i=0; i<PDIM; ++i)
             {
-                p0[i] = P[left.first*DIM+i];
-                p1[i] = P[right.first*DIM+i];
+                p0[i] = P[left.first*PDIM+i];
+                p1[i] = P[right.first*PDIM+i];
             }
             bool d_hit = default_discrete_test(V1, p0, p1);
             if (d_hit && append_discrete != nullptr)
@@ -395,7 +396,8 @@ void BVHTree<T,DIM,PDIM>::get_candidates(int p0, int p1, const int *P,
                 pair.second = -1;
     }
 
-    if (PDIM != 3)
+    // Skip edge-edge if not in 3D
+    if (DIM != 3)
         return;
 
     // EE
@@ -462,10 +464,15 @@ bool BVHTree<T,DIM,PDIM>::boxes_intersect(const NodeIndex &left, const NodeIndex
 template <typename T, int DIM, int PDIM>
 T BVHTree<T,DIM,PDIM>::default_narrow_phase(const T* V0, const T* V1, const Eigen::Vector4i &sten, bool is_vf) const
 {
-    VecType verts0[4], verts1[4];
-    for (int i=0; i<4; ++i)
+    // stencil is PDIM + 1, i.e., edges = vertex-edge, triangles = vertex-triangle or edge-edge
+    VecType verts0[PDIM+1], verts1[PDIM+1];
+    for (int i=0; i<PDIM+1; ++i)
     {
-        assert(sten[i] >= 0);
+        if (sten[i] < 0)
+        {
+            return -2; // error
+        }
+
         for (int j=0; j<DIM; ++j)
         {
             verts0[i][j] = V0[sten[i]*DIM+j];
@@ -494,36 +501,62 @@ template <typename T, int DIM, int PDIM>
 bool BVHTree<T,DIM,PDIM>::default_discrete_test(const T* V, const int *p0, const int *p1) const
 {
     // Shares vertex?
-    for (int i=0; i<DIM; ++i)
-        for (int j=0; j<DIM; ++j)
+    for (int i=0; i<PDIM; ++i)
+        for (int j=0; j<PDIM; ++j)
             if (p0[i] == p1[j])
                 return false;
 
-    if (DIM == 3)
+    if (DIM == 3 && PDIM == 3)
     {
-        Eigen::Matrix<T,3,1> v0[DIM], v1[DIM];
+        Eigen::Vector3<T> v0[3], v1[3];
         for (int i=0; i<3; ++i)
         {
             for (int j=0; j<3; ++j)
             {
-                v0[i][j] = V[p0[i]*DIM+j];
-                v1[i][j] = V[p1[i]*DIM+j];
+                v0[i][j] = V[p0[i]*3+j];
+                v1[i][j] = V[p1[i]*3+j];
             }
         }
         return NarrowPhase<T,3>::discrete_tri_tri(v0, v1);
     }
-    else if (DIM == 2)
+    else if (DIM == 2 && PDIM == 2)
     {
-        Eigen::Matrix<T,2,1> v0[DIM], v1[DIM];
+        Eigen::Vector2<T> v0[2], v1[2];
         for (int i=0; i<2; ++i)
         {
             for (int j=0; j<2; ++j)
             {
-                v0[i][j] = V[p0[i]*DIM+j];
-                v1[i][j] = V[p1[i]*DIM+j];
+                v0[i][j] = V[p0[i]*2+j];
+                v1[i][j] = V[p1[i]*2+j];
             }
         }
         return NarrowPhase<T,2>::discrete_edge_edge(v0, v1); 
+    }
+    else if (DIM == 2 && PDIM == 3)
+    {
+        // two triangles = 6 edge-edge tests
+        for (int p0_i=0; p0_i<3; ++p0_i)
+        {
+            Eigen::Vector2<T> v0[2];
+            v0[0][0] = V[p0[p0_i]*2+0];
+            v0[0][1] = V[p0[p0_i]*2+1];
+            v0[1][0] = V[p0[(p0_i+1)%3]*2+0];
+            v0[1][1] = V[p0[(p0_i+1)%3]*2+1];
+
+            for (int p1_i=0; p1_i<3; ++p1_i)
+            {
+                Eigen::Vector2<T> v1[2];
+                v1[0][0] = V[p1[p1_i]*2+0];
+                v1[0][1] = V[p1[p1_i]*2+1];
+                v1[1][0] = V[p1[(p1_i+1)%3]*2+0];
+                v1[1][1] = V[p1[(p1_i+1)%3]*2+1];
+
+                if (NarrowPhase<T,2>::discrete_edge_edge(v0, v1)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     return false;

--- a/src/MCL/BVHTree.cpp
+++ b/src/MCL/BVHTree.cpp
@@ -19,14 +19,14 @@ namespace mcl
 namespace ccd
 {
 
-template <typename T, int DIM>
-BVHTree<T,DIM>::BVHTree()
+template <typename T, int DIM, int PDIM>
+BVHTree<T,DIM,PDIM>::BVHTree()
 {
     tree = std::make_shared<Eigen::KdBVH<T,DIM,LeafType> >();
 }
 
-template <typename T, int DIM>
-void BVHTree<T,DIM>::update(const T* V0, const T* V1, const int *P, int np, int pdim, const int *active)
+template <typename T, int DIM, int PDIM>
+void BVHTree<T,DIM,PDIM>::update(const T* V0, const T* V1, const int *P, int np, const int *active)
 {
     if (np == 0)
     {
@@ -48,7 +48,7 @@ void BVHTree<T,DIM>::update(const T* V0, const T* V1, const int *P, int np, int 
     if ((int)leaves.size() != np)
     {
         leaves.resize(np);
-        update_reptri = pdim == 2 || pdim == 3;
+        update_reptri = PDIM == 2 || PDIM == 3;
     }
 
     // Update representative triangles
@@ -62,18 +62,18 @@ void BVHTree<T,DIM>::update(const T* V0, const T* V1, const int *P, int np, int 
             BVHLeaf<T,DIM> &leaf = leaves[i];
             leaf.v.setZero();
             leaf.e.setZero();
-            for (int j=0; j<pdim; ++j)
+            for (int j=0; j<PDIM; ++j)
             {
-                int vi = P[i*pdim+j];
+                int vi = P[i*PDIM+j];
                 bool v_not_seen = seen_verts.emplace(vi).second;
                 if (v_not_seen)
                     leaf.v[j]=1;
 
-                if (pdim != 3)
+                if (PDIM != 3)
                     continue;
 
                 int e0 = vi;
-                int e1 = P[i*pdim+((j+1)%3)];
+                int e1 = P[i*PDIM+((j+1)%3)];
                 if (e1 < e0) { std::swap(e0, e1); }
                 std::string h = std::to_string(e0)+' '+std::to_string(e1);
                 bool e_not_seen = seen_edges.emplace(h).second;
@@ -96,9 +96,9 @@ void BVHTree<T,DIM>::update(const T* V0, const T* V1, const int *P, int np, int 
         leaf.box.setEmpty();
         leaf.box.t0.setEmpty();
         leaf.box.t1.setEmpty();
-        for (int j=0; j<pdim; ++j)
+        for (int j=0; j<PDIM; ++j)
         {
-            int vi = P[i*pdim + j];
+            int vi = P[i*PDIM + j];
             VecType xi_t0 = VecType::Zero();
             VecType xi_t1 = VecType::Zero();
             for (int k=0; k<DIM; ++k)
@@ -129,8 +129,8 @@ void BVHTree<T,DIM>::update(const T* V0, const T* V1, const int *P, int np, int 
 
 }
 
-template <typename T, int DIM>
-void BVHTree<T,DIM>::traverse(const T* V0, const T* V1, const int *P) const
+template <typename T, int DIM, int PDIM>
+void BVHTree<T,DIM,PDIM>::traverse(const T* V0, const T* V1, const int *P) const
 {
     if (leaves.size() <= 1)
         return;
@@ -143,7 +143,7 @@ void BVHTree<T,DIM>::traverse(const T* V0, const T* V1, const int *P) const
     std::atomic<int> stop(0);
 
     int nq = queue.size();
-    if (options.threaded)
+    if (options.parallel)
     {
         tbb::parallel_for(tbb::blocked_range<int>(0,nq), [&](const tbb::blocked_range<int>& r)
         {
@@ -162,15 +162,15 @@ void BVHTree<T,DIM>::traverse(const T* V0, const T* V1, const int *P) const
     }
 }
 
-template <typename T, int DIM>
-void BVHTree<T,DIM>::traverse(BVHTraverse<T,DIM> *traverser) const
+template <typename T, int DIM, int PDIM>
+void BVHTree<T,DIM,PDIM>::traverse(BVHTraverse<T,DIM> *traverser) const
 {
     const Eigen::KdBVH<T,DIM,LeafType> &tree_ref = *tree.get();
     Eigen::BVIntersect(tree_ref, *traverser);
 }
 
-template <typename T, int DIM>
-void BVHTree<T,DIM>::make_frontlist(const NodeIndex &idx,
+template <typename T, int DIM, int PDIM>
+void BVHTree<T,DIM,PDIM>::make_frontlist(const NodeIndex &idx,
     std::vector<std::pair<NodeIndex,NodeIndex> > &queue) const
 {
     if (idx.second) // is leaf node
@@ -188,8 +188,8 @@ void BVHTree<T,DIM>::make_frontlist(const NodeIndex &idx,
     queue.emplace_back(l, r);
 }
 
-template <typename T, int DIM>
-void BVHTree<T,DIM>::get_children(const NodeIndex &idx, NodeIndex &l, NodeIndex &r) const
+template <typename T, int DIM, int PDIM>
+void BVHTree<T,DIM,PDIM>::get_children(const NodeIndex &idx, NodeIndex &l, NodeIndex &r) const
 {
     typedef typename Eigen::KdBVH<T, DIM, BVHLeaf<T,DIM> >::VolumeIterator VolumeIter;
     typedef typename Eigen::KdBVH<T, DIM, BVHLeaf<T,DIM> >::ObjectIterator ObjectIter;
@@ -223,15 +223,15 @@ void BVHTree<T,DIM>::get_children(const NodeIndex &idx, NodeIndex &l, NodeIndex 
     assert(num_children == 2); // assumes binary tree
 }
 
-template <typename T, int DIM>
-const typename BVHLeaf<T,DIM>::BoxType& BVHTree<T,DIM>::get_box(const NodeIndex &idx) const
+template <typename T, int DIM, int PDIM>
+const typename BVHLeaf<T,DIM>::BoxType& BVHTree<T,DIM,PDIM>::get_box(const NodeIndex &idx) const
 {
     if (idx.second) { return leaves[idx.first].box; }
     return tree->getVolume(idx.first);
 }
 
-template <typename T, int DIM>
-void BVHTree<T,DIM>::collide(
+template <typename T, int DIM, int PDIM>
+void BVHTree<T,DIM,PDIM>::collide(
     const T* V0, const T* V1, const int *P,
     const NodeIndex &left, const NodeIndex &right,
     std::atomic<int> &stop) const
@@ -257,7 +257,7 @@ void BVHTree<T,DIM>::collide(
         {
             std::array<PairType, NumCandidates> pairs;
             get_candidates(left.first, right.first, P, pairs);
-            for (int i=0; i<NumCandidates; ++i)
+            for (size_t i=0; i<NumCandidates; ++i)
             {
                 if (pairs[i].second < 0) {
                     continue;
@@ -308,29 +308,29 @@ void BVHTree<T,DIM>::collide(
     }
 }
 
-template <typename T, int DIM>
-void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
+template <typename T, int DIM, int PDIM>
+void BVHTree<T,DIM,PDIM>::get_candidates(int p0, int p1, const int *P,
     std::array<PairType, NumCandidates> &pairs) const
 {
     const LeafType& l0 = leaves[p0];
     const LeafType& l1 = leaves[p1];
 
-    for (int i=0; i<NumCandidates; ++i)
+    for (size_t i=0; i<NumCandidates; ++i)
     {
         pairs[i].first.setZero();
         pairs[i].second = -1;
     }
 
-    int f0[DIM], f1[DIM];
-    for (int i=0; i<DIM; ++i)
+    int f0[PDIM], f1[PDIM];
+    for (int i=0; i<PDIM; ++i)
     {
-        f0[i] = P[p0*DIM+i];
-        f1[i] = P[p1*DIM+i];
+        f0[i] = P[p0*PDIM+i];
+        f1[i] = P[p1*PDIM+i];
     }
 
     auto vf_shared_vertex = [](int vi, const int *fi)->bool
     {
-        for (int i=0; i<DIM; ++i)
+        for (int i=0; i<PDIM; ++i)
             if (vi == fi[i])
                 return true;
 
@@ -340,7 +340,7 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
     int pair_index = 0;
 
     // VF, f0 -> f1
-    for (int i=0; i<DIM; ++i)
+    for (int i=0; i<PDIM; ++i)
     {
         if (!l0.v[i]) // v not represented
         {
@@ -359,7 +359,7 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
 
         pair.first = Eigen::Vector4i(-1,-1,-1,-1);
         pair.first[0] = f0[i];
-        for (int j=0; j<DIM; ++j)
+        for (int j=0; j<PDIM; ++j)
             pair.first[j+1] = f1[j];
 
         if (filter_pair != nullptr)
@@ -368,7 +368,7 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
     }
 
     // VF, f1 -> f0
-    for (int i=0; i<DIM; ++i)
+    for (int i=0; i<PDIM; ++i)
     {
         if (!l1.v[i]) // v not represented
         {
@@ -387,7 +387,7 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
 
         pair.first = Eigen::Vector4i(-1,-1,-1,-1);
         pair.first[0] = f1[i];
-        for (int j=0; j<DIM; ++j)
+        for (int j=0; j<PDIM; ++j)
             pair.first[j+1] = f0[j];
 
         if (filter_pair != nullptr)
@@ -395,7 +395,7 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
                 pair.second = -1;
     }
 
-    if (DIM != 3)
+    if (PDIM != 3)
         return;
 
     // EE
@@ -431,8 +431,8 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
     }
 }
 
-template <typename T, int DIM>
-bool BVHTree<T,DIM>::boxes_intersect(const NodeIndex &left, const NodeIndex &right) const
+template <typename T, int DIM, int PDIM>
+bool BVHTree<T,DIM,PDIM>::boxes_intersect(const NodeIndex &left, const NodeIndex &right) const
 {
     const typename BVHLeaf<T,DIM>::BoxType &lbox = get_box(left);
     const typename BVHLeaf<T,DIM>::BoxType &rbox = get_box(right);
@@ -459,11 +459,11 @@ bool BVHTree<T,DIM>::boxes_intersect(const NodeIndex &left, const NodeIndex &rig
     return true;
 }
 
-template <typename T, int DIM>
-T BVHTree<T,DIM>::default_narrow_phase(const T* V0, const T* V1, const Eigen::Vector4i &sten, bool is_vf) const
+template <typename T, int DIM, int PDIM>
+T BVHTree<T,DIM,PDIM>::default_narrow_phase(const T* V0, const T* V1, const Eigen::Vector4i &sten, bool is_vf) const
 {
-    VecType verts0[DIM+1], verts1[DIM+1];
-    for (int i=0; i<DIM+1; ++i)
+    VecType verts0[4], verts1[4];
+    for (int i=0; i<4; ++i)
     {
         assert(sten[i] >= 0);
         for (int j=0; j<DIM; ++j)
@@ -490,8 +490,8 @@ T BVHTree<T,DIM>::default_narrow_phase(const T* V0, const T* V1, const Eigen::Ve
     return -1;
 }
 
-template <typename T, int DIM>
-bool BVHTree<T,DIM>::default_discrete_test(const T* V, const int *p0, const int *p1) const
+template <typename T, int DIM, int PDIM>
+bool BVHTree<T,DIM,PDIM>::default_discrete_test(const T* V, const int *p0, const int *p1) const
 {
     // Shares vertex?
     for (int i=0; i<DIM; ++i)
@@ -532,7 +532,7 @@ bool BVHTree<T,DIM>::default_discrete_test(const T* V, const int *p0, const int 
 } // end namespace ccd
 } // end namespace mcl
 
-template class mcl::ccd::BVHTree<double,3>;
-template class mcl::ccd::BVHTree<double,2>;
-template class mcl::ccd::BVHTree<float,3>;
-template class mcl::ccd::BVHTree<float,2>;
+template class mcl::ccd::BVHTree<double,3,3>;
+template class mcl::ccd::BVHTree<double,2,3>;
+template class mcl::ccd::BVHTree<float,3,3>;
+template class mcl::ccd::BVHTree<float,2,3>;

--- a/src/MCL/BVHTree.cpp
+++ b/src/MCL/BVHTree.cpp
@@ -35,11 +35,13 @@ void BVHTree<T,DIM>::update(const T* V0, const T* V1, const int *P, int np, int 
         return;
     }
 
-    assert(options.box_eta >= 0);
     assert(options.vf_ccd_eta >= 0);
     assert(options.ee_ccd_eta >= 0);
-    options.vf_ccd_eta = std::min(options.vf_ccd_eta, options.box_eta);
-    options.ee_ccd_eta = std::min(options.ee_ccd_eta, options.box_eta);
+    T box_eta = options.vf_ccd_eta;
+    if (DIM == 3)
+    {
+        box_eta = std::max(box_eta, options.ee_ccd_eta);
+    }
 
     bool update_reptri = false;
 
@@ -50,7 +52,7 @@ void BVHTree<T,DIM>::update(const T* V0, const T* V1, const int *P, int np, int 
     }
 
     // Update representative triangles
-    if (options.reptri && update_reptri)
+    if (update_reptri)
     {
         std::unordered_set<int> seen_verts;
         std::set<std::string> seen_edges;
@@ -113,12 +115,12 @@ void BVHTree<T,DIM>::update(const T* V0, const T* V1, const int *P, int np, int 
                 if (active[vi])
                     leaf.box.active = true;
         }
-        leaf.box.t0.min().array() -= options.box_eta;
-        leaf.box.t1.min().array() -= options.box_eta;
-        leaf.box.min().array() -= options.box_eta;
-        leaf.box.t0.max().array() += options.box_eta;
-        leaf.box.t1.max().array() += options.box_eta;
-        leaf.box.max().array() += options.box_eta;
+        leaf.box.t0.min().array() -= box_eta;
+        leaf.box.t1.min().array() -= box_eta;
+        leaf.box.min().array() -= box_eta;
+        leaf.box.t0.max().array() += box_eta;
+        leaf.box.t1.max().array() += box_eta;
+        leaf.box.max().array() += box_eta;
       }
     });
 
@@ -445,11 +447,7 @@ T BVHTree<T,DIM>::default_narrow_phase(const T* V0, const T* V1, const Eigen::Ve
     int hit = 0;
     if (is_vf)
     {
-        if (options.vf_one_sided) {
-            hit = NarrowPhaseCTCD<T,DIM>::query_ccd_vf(verts0, verts1, options.vf_ccd_eta, options.vf_one_sided, toi);
-        } else {
-            hit = NarrowPhaseACCD<T,DIM>::query_ccd_vf(verts0, verts1, options.vf_ccd_eta, toi);
-        }
+        hit = NarrowPhaseACCD<T,DIM>::query_ccd_vf(verts0, verts1, options.vf_ccd_eta, toi);
     }
     else
     {

--- a/src/MCL/BVHTree.cpp
+++ b/src/MCL/BVHTree.cpp
@@ -255,12 +255,15 @@ void BVHTree<T,DIM>::collide(
     {
         if (options.continuous)
         {
-            std::vector<PairType> pairs;
+            std::array<PairType, NumCandidates> pairs;
             get_candidates(left.first, right.first, P, pairs);
-            int num_pairs = pairs.size();
-            for (int i=0; i<num_pairs; ++i)
+            for (int i=0; i<NumCandidates; ++i)
             {
-                T toi = -1;//narrow_phase(nf);
+                if (pairs[i].second < 0) {
+                    continue;
+                }
+
+                T toi = -1;
                 if (narrow_phase != nullptr) { toi = narrow_phase(pairs[i].first, pairs[i].second); }
                 else { toi = default_narrow_phase(V0, V1, pairs[i].first, pairs[i].second); }
                 if (toi >= 0 && append_pair != nullptr)
@@ -307,10 +310,16 @@ void BVHTree<T,DIM>::collide(
 
 template <typename T, int DIM>
 void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
-    std::vector<PairType> &pairs) const
+    std::array<PairType, NumCandidates> &pairs) const
 {
     const LeafType& l0 = leaves[p0];
     const LeafType& l1 = leaves[p1];
+
+    for (int i=0; i<NumCandidates; ++i)
+    {
+        pairs[i].first.setZero();
+        pairs[i].second = -1;
+    }
 
     int f0[DIM], f1[DIM];
     for (int i=0; i<DIM; ++i)
@@ -328,18 +337,25 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
         return false;
     };
 
+    int pair_index = 0;
+
     // VF, f0 -> f1
     for (int i=0; i<DIM; ++i)
     {
         if (!l0.v[i]) // v not represented
+        {
+            pairs[pair_index++].second = -1;
             continue;
+        }
 
         if (vf_shared_vertex(f0[i], f1))
+        {
+            pairs[pair_index++].second = -1;
             continue;
-
-        pairs.emplace_back();
-        PairType &pair = pairs.back();
-        pair.second = true; // is_vf
+        }
+    
+        PairType &pair = pairs[pair_index++];
+        pair.second = 1; // is_vf
 
         pair.first = Eigen::Vector4i(-1,-1,-1,-1);
         pair.first[0] = f0[i];
@@ -348,21 +364,26 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
 
         if (filter_pair != nullptr)
             if (filter_pair(pair.first, pair.second))
-                pairs.pop_back();
+                pair.second = -1;
     }
 
     // VF, f1 -> f0
     for (int i=0; i<DIM; ++i)
     {
         if (!l1.v[i]) // v not represented
+        {
+            pairs[pair_index++].second = -1;
             continue;
+        }
 
         if (vf_shared_vertex(f1[i], f0))
+        {
+            pairs[pair_index++].second = -1;
             continue;
+        }
 
-        pairs.emplace_back();
-        PairType &pair = pairs.back();
-        pair.second = true; // is_vf
+        PairType &pair = pairs[pair_index++];
+        pair.second = 1; // is_vf
 
         pair.first = Eigen::Vector4i(-1,-1,-1,-1);
         pair.first[0] = f1[i];
@@ -371,7 +392,7 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
 
         if (filter_pair != nullptr)
             if (filter_pair(pair.first, pair.second))
-                pairs.pop_back();
+                pair.second = -1;
     }
 
     if (DIM != 3)
@@ -383,20 +404,29 @@ void BVHTree<T,DIM>::get_candidates(int p0, int p1, const int *P,
         if (!l0.e[i]) { continue; }
         for (int j=0; j<3; ++j)
         {
-            if (!l1.e[j]) { continue; }
+            if (!l1.e[j])
+            {
+                pairs[pair_index++].second = -1;
+                continue;
+            }
+
             Eigen::Vector4i sten(i, (i+1)%3, j, (j+1)%3);
+
+            // shares vertex?
             if (f0[sten[0]]==f1[sten[2]] || f0[sten[0]]==f1[sten[3]] ||
                 f0[sten[1]]==f1[sten[2]] || f0[sten[1]]==f1[sten[3]])
-                continue; // shares vertex
+            {
+                pairs[pair_index++].second = -1;
+                continue;
+            }
 
-            pairs.emplace_back();
-            PairType &pair = pairs.back();
-            pair.second = false; // is not vf
+            PairType &pair = pairs[pair_index++];
+            pair.second = 0; // is not vf
             pair.first = Eigen::Vector4i(f0[sten[0]], f0[sten[1]], f1[sten[2]], f1[sten[3]]);
 
             if (filter_pair != nullptr)
                 if (filter_pair(pair.first, pair.second))
-                    pairs.pop_back();
+                    pair.second = -1;
         }
     }
 }

--- a/src/MCL/BVHTree.hpp
+++ b/src/MCL/BVHTree.hpp
@@ -37,31 +37,24 @@ public:
     typedef Eigen::Matrix<T,DIM,1> VecType;
     typedef std::pair<Eigen::Vector4i,bool> PairType; // [sten, is_vf]
     typedef std::pair<int, bool> NodeIndex; // [index, isleaf]
+    //constexpr int NumCandidates = DIM == 2 ? 
 
     std::vector<LeafType> leaves;
     std::shared_ptr<Eigen::KdBVH<T,DIM,LeafType> > tree;
 
     struct Options
     {
-        T box_eta; // padding of tree boxes
-        T vf_ccd_eta; // gap for vf narrowphase <= box_eta
-        T ee_ccd_eta; // gap for ee narrowphase <= box_eta
-        bool reptri; // representative triangles
+        T vf_ccd_eta; // gap for vf narrowphase
+        T ee_ccd_eta; // gap for ee narrowphase
         bool threaded; // cpu-threaded traverse(...)
         bool discrete; // discrete check ff/ee at V1
         bool continuous; // ccd check from V0 to V1
-        bool vf_one_sided; // allow pass-through if norm dir
-        bool ee_robust; // check VV and VE (if CTCD kernels)
         Options() :
-            box_eta(1e-6),
             vf_ccd_eta(1e-6),
             ee_ccd_eta(1e-6),
-            reptri(true),
             threaded(true),
             discrete(true),
-            continuous(true),
-            vf_one_sided(false),
-            ee_robust(true)
+            continuous(true)
             {}
     } options;
 

--- a/src/MCL/BVHTree.hpp
+++ b/src/MCL/BVHTree.hpp
@@ -5,8 +5,11 @@
 #define MCL_CCD_BVHTREE_HPP 1
 
 #include "BVHLeaf.hpp"
+
 #include <atomic>
 #include <memory>
+#include <vector>
+#include <stdexcept>
 
 namespace Eigen // Forward declare BVH type, then include in cpp
 { template <typename T,int DIM, class Object> class KdBVH; }
@@ -17,7 +20,7 @@ namespace ccd
 {
 
 // Traversal struct for things like point-in-elem queries
-template <typename T, int DIM>
+template <typename T, int DIM, int PDIM=3>
 class BVHTraverse
 {
 public:
@@ -29,7 +32,7 @@ public:
 };
 
 // Wraps Eigen BVH and provides functions for CCD traversal
-template <typename T, int DIM>
+template <typename T, int DIM, int PDIM=3>
 class BVHTree
 {
 public:
@@ -46,13 +49,13 @@ public:
     {
         T vf_ccd_eta; // gap for vf narrowphase
         T ee_ccd_eta; // gap for ee narrowphase
-        bool threaded; // cpu-threaded traverse(...)
+        bool parallel; // cpu-threaded traverse(...)
         bool discrete; // discrete check ff/ee at V1
-        bool continuous; // ccd check from V0 to V1
+        bool continuous; // ccd check from V0 to V1 (triangles only)
         Options() :
             vf_ccd_eta(1e-6),
             ee_ccd_eta(1e-6),
-            threaded(true),
+            parallel(true),
             discrete(true),
             continuous(true)
             {}
@@ -62,7 +65,7 @@ public:
     virtual ~BVHTree() {}
 
     // V is n x dim with V0 at t=0 and V1 at t=1.
-    // P can be m x (whatever) depending on the prim (1=pt, 2=edge, 3=tri, etc)
+    // P can be m x 3 or 4, depending on the prim (tri or tet)
     // Active is a per-vertex boolean if the vertex should be checked.
     // if active buffer empty, all vertices considered active.
     template <typename DerivedV, typename DerivedP>
@@ -73,8 +76,7 @@ public:
         const Eigen::VectorXi &active = Eigen::VectorXi());
 
     // Update BVH using raw data.
-    void update(const T* V0, const T* V1, const int *P, int np, int pdim,
-        const int *active = nullptr);
+    void update(const T* V0, const T* V1, const int *P, int np, const int *active = nullptr);
     
     // Traverses tree and checks from V0 to V1 with P = edges (DIM=2) or faces (DIM==3).
     // Calls narrow_phase, append_pair, and append_discrete.
@@ -143,35 +145,47 @@ protected:
 }; // class BVHTree
 
 // Convert matrix to needed type
-template <typename T, int DIM>
+template <typename T, int DIM, int PDIM>
 template <typename DerivedV, typename DerivedP>
-inline void BVHTree<T,DIM>::update(
+inline void BVHTree<T,DIM,PDIM>::update(
     const Eigen::MatrixBase<DerivedV> &V0,
     const Eigen::MatrixBase<DerivedV> &V1,
     const Eigen::MatrixBase<DerivedP> &P,
     const Eigen::VectorXi &active)
 {
-    // TODO avoid copy. But MatrixBase doesn't have a data() function.
+    // TODO avoid copy
     if (V0.rows() != V1.rows()) { return; }
+    if (V0.cols() != DIM || V1.cols() != DIM) {
+        throw std::runtime_error("V.cols != DIM");
+    }
+    if (P.cols() != PDIM) {
+        throw std::runtime_error("P.cols != PDIM");
+    }
     const int *active_ptr = active.size() == V0.rows() ? active.data() : nullptr;
     typedef Eigen::Matrix<T,Eigen::Dynamic,DIM,Eigen::RowMajor> ScalarMat;
     typedef Eigen::Matrix<int,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> IndexMat;
     ScalarMat V0cpy = V0.template cast<T>();
     ScalarMat V1cpy = V1.template cast<T>();
     IndexMat Pcpy = P.template cast<int>();
-    update(V0cpy.data(), V1cpy.data(), Pcpy.data(), P.rows(), P.cols(), active_ptr);
+    update(V0cpy.data(), V1cpy.data(), Pcpy.data(), P.rows(), active_ptr);
 }
 
 // Convert matrix to needed type
-template <typename T, int DIM>
+template <typename T, int DIM, int PDIM>
 template <typename DerivedV, typename DerivedP>
-inline void BVHTree<T,DIM>::traverse(
+inline void BVHTree<T,DIM,PDIM>::traverse(
     const Eigen::MatrixBase<DerivedV> &V0,
     const Eigen::MatrixBase<DerivedV> &V1,
     const Eigen::MatrixBase<DerivedP> &P)
 {
-    // TODO avoid copy. But MatrixBase doesn't have a data() function.
+    // TODO avoid copy.
     if (V0.rows() != V1.rows()) { return; }
+    if (V0.cols() != DIM || V1.cols() != DIM) {
+        throw std::runtime_error("V.cols != DIM");
+    }
+    if (P.cols() != PDIM) {
+        throw std::runtime_error("P.cols != PDIM");
+    }
     typedef Eigen::Matrix<T,Eigen::Dynamic,DIM,Eigen::RowMajor> ScalarMat;
     typedef Eigen::Matrix<int,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor> IndexMat;
     ScalarMat V0cpy = V0.template cast<T>();

--- a/src/MCL/BVHTree.hpp
+++ b/src/MCL/BVHTree.hpp
@@ -51,7 +51,7 @@ public:
         T ee_ccd_eta; // gap for ee narrowphase
         bool parallel; // cpu-threaded traverse(...)
         bool discrete; // discrete check ff/ee at V1
-        bool continuous; // ccd check from V0 to V1 (triangles only)
+        bool continuous; // ccd check from V0 to V1 (3D triangles only)
         Options() :
             vf_ccd_eta(1e-6),
             ee_ccd_eta(1e-6),

--- a/src/MCL/BVHTree.hpp
+++ b/src/MCL/BVHTree.hpp
@@ -35,9 +35,9 @@ class BVHTree
 public:
     typedef BVHLeaf<T,DIM> LeafType;
     typedef Eigen::Matrix<T,DIM,1> VecType;
-    typedef std::pair<Eigen::Vector4i,bool> PairType; // [sten, is_vf]
+    typedef std::pair<Eigen::Vector4i,int> PairType; // [sten, -1=invalid, 0=ee, 1=vf]
     typedef std::pair<int, bool> NodeIndex; // [index, isleaf]
-    //constexpr int NumCandidates = DIM == 2 ? 
+    static const size_t NumCandidates = DIM == 2 ? 6 : 15; // narrowphase candidates
 
     std::vector<LeafType> leaves;
     std::shared_ptr<Eigen::KdBVH<T,DIM,LeafType> > tree;
@@ -131,7 +131,7 @@ protected:
     // Creates list of broadphase pairs from rep-tris and no shared vertex
     // pairs = stencil, type
     void get_candidates(int p0, int p1, const int *P,
-        std::vector<PairType> &pairs) const;
+        std::array<PairType, NumCandidates> &pairs) const;
 
     bool boxes_intersect(const NodeIndex &left, const NodeIndex &right) const;
 

--- a/src/MCL/NarrowPhase.cpp
+++ b/src/MCL/NarrowPhase.cpp
@@ -68,7 +68,7 @@ bool NarrowPhase<double,3>::hit_wrong_side_vf(
 	// Resting contact, relative velocity=0
 	// and so there is no way to tell.
 	if (std::abs(t) <= 0.0) { return false; }
-	std::vector<Vector3d> xt = {
+	std::array<Vector3d, 4> xt = {
 		verts0[0]*(1.0-t) + verts1[0]*t,
 		verts0[1]*(1.0-t) + verts1[1]*t,
 		verts0[2]*(1.0-t) + verts1[2]*t,
@@ -142,11 +142,11 @@ bool NarrowPhase<double,3>::query_ray_box(
 	dir.normalize();
 	typedef Matrix<double,1,3>  RowVector3S;
 	const RowVector3S inv_dir( 1./dir(0),1./dir(1),1./dir(2));
-	const std::vector<bool> sign = { inv_dir(0)<0, inv_dir(1)<0, inv_dir(2)<0};
+	const std::array<bool, 3> sign = { inv_dir(0)<0, inv_dir(1)<0, inv_dir(2)<0};
 	// http://people.csail.mit.edu/amy/papers/box-jgt.pdf
 	// "An Efficient and Robust Ray–Box Intersection Algorithm"
 	double tymin, tymax, tzmin, tzmax;
-	std::vector<RowVector3S> bounds = {bmin, bmax};
+	std::array<RowVector3S, 2> bounds = {bmin, bmax};
 	double tmin = ( bounds[sign[0]](0) - origin(0)) * inv_dir(0);
 	double tmax = ( bounds[1-sign[0]](0) - origin(0)) * inv_dir(0);
 	tymin = (bounds[sign[1]](1)   - origin(1)) * inv_dir(1);

--- a/src/MCL/NarrowPhase.cpp
+++ b/src/MCL/NarrowPhase.cpp
@@ -549,7 +549,7 @@ int NarrowPhaseCTCD<double,3>::query_ccd_ee(
 
             // Check if the edges are parallel
             // The edgeEdgeCTCD sometimes returns toi for parallel edges!
-            std::vector<Vector3d> vt = {
+            std::array<Vector3d, 4> vt = {
                 (1.0-all_toi[i]) * verts0[0] + all_toi[i]*verts1[0],
                 (1.0-all_toi[i]) * verts0[1] + all_toi[i]*verts1[1],
                 (1.0-all_toi[i]) * verts0[2] + all_toi[i]*verts1[2],

--- a/test/dillo.cpp
+++ b/test/dillo.cpp
@@ -54,7 +54,8 @@ int main(int, char**)
     std::cout << "Building the tree: " << std::flush; 
     timer.start();
     mcl::ccd::BVHTree<double,3> tree;
-    tree.options.box_eta = std::numeric_limits<float>::epsilon();
+    tree.options.vf_ccd_eta = std::numeric_limits<float>::epsilon();
+    tree.options.ee_ccd_eta = std::numeric_limits<float>::epsilon();
     tree.update(V, V, F);
     std::cout << timer.getElapsedTimeInMilliSec() << " ms" << std::endl;
 

--- a/test/test_2D.cpp
+++ b/test/test_2D.cpp
@@ -2,10 +2,47 @@
 // Distributed under the MIT License.
 
 #include "MCL/BVHTree.hpp"
+#include <stdexcept>
+
+void assert_true(bool condition, const std::string &msg)
+{
+    if (!condition)
+    {
+        throw std::runtime_error(msg);
+    }
+}
 
 int main(int, char**)
 {
-    // TODO
-    mcl::ccd::BVHTree<double,3> tree;
+    // Three triangles, discrete
+    {
+        mcl::ccd::BVHTree<double,2> tree;
+        tree.options.parallel = false;
+        Eigen::MatrixXd V(9,2);
+        V <<    0, 0,
+                0, 1,
+                1, 0,
+                0.5, 0.5,
+                0.5, 1.5,
+                1.5, 0.5,
+                10, 10,
+                10, 11,
+                11, 10;
+        Eigen::MatrixXi F(3, 3);
+        F << 0, 1, 2, 3, 4, 5, 6, 7, 8;
+
+        std::vector<Eigen::Vector2i> pairs;        
+        tree.update(V, V, F);
+        tree.append_discrete = [&](int p0, int p1)->bool
+        {
+            pairs.emplace_back((p0 > p1) ? Eigen::Vector2i(p0, p1) : Eigen::Vector2i(p1, p0));
+            return false;
+        };
+
+        assert_true(pairs.size() == 1, "didn't detect single intersection");
+        assert_true(pairs[0][0] == 0 && pairs[0][1] == 1, "bad intersection prim idx");
+    }
+
+
     return EXIT_SUCCESS;
 }

--- a/test/test_2D.cpp
+++ b/test/test_2D.cpp
@@ -38,9 +38,10 @@ int main(int, char**)
             pairs.emplace_back((p0 > p1) ? Eigen::Vector2i(p0, p1) : Eigen::Vector2i(p1, p0));
             return false;
         };
+        tree.traverse(V, V, F);
 
         assert_true(pairs.size() == 1, "didn't detect single intersection");
-        assert_true(pairs[0][0] == 0 && pairs[0][1] == 1, "bad intersection prim idx");
+        assert_true(pairs[0][0] == 1 && pairs[0][1] == 0, "bad intersection prim idx");
     }
 
 


### PR DESCRIPTION
- PDIM template to fix/specialize inner loops and disambiguate primitive types (edge vs triangle vs tet)
- Replaced std::vector with std::array to avoid heap allocation in kernel funcs
- Removed options that are no longer relevant from BVHTree