### PR TITLE
Unrolled some loops for getting prims/vertices; Tree shared_ptr to unique_ptr;

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Copyright Matt Overby 2021.
 # Distributed under the MIT License.
+
 cmake_minimum_required(VERSION 3.0)
 project(mclccd LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-include(FetchContent)
 
 option(MCLCCD_DEBUG "Compile in test mode" OFF)
 option(MCLCCD_TESTING_ONLY "only compile unit tests" OFF)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Continuous collision detection for 2D and 3D triangular meshes.
 
 ## Build
 
+Dependencies:
+- Eigen ([https://gitlab.com/libeigen/eigen](https://gitlab.com/libeigen/eigen))
+- Thread Building Blocks ([https://github.com/uxlfoundation/oneTBB](https://github.com/uxlfoundation/oneTBB))
+
 ```sh
 mkdir build
 cd build
@@ -22,12 +26,10 @@ Eigen::MatrixXd V1 = ... // nv x 2 or 3 vertices at t=1
 Eigen::MatrixXi F = ... // nf x 3 triangles
 mcl::BVHTree<double,3> tree;
 tree.update(V0, V1, F); // creates or updates BVH
-tree.append_pair = [&](const Eigen::Vector4i &sten, int type, const double &toi)->void
-{
+tree.append_pair = [&](const Eigen::Vector4i &sten, int type, const double &toi)->void {
     contacts.emplace_back(sten, type, toi);
 };
-tree.append_discrete = [&](int p0, int p1)->bool
-{
+tree.append_discrete = [&](int p0, int p1)->bool {
     discrete.emplace(p0, p1); // tri-tri or edge-edge
     return false; // return true to stop traversing
 };
@@ -37,13 +39,11 @@ tree.traverse(V0, V1, F); // perform collision detection
 By default, CCD uses [ACCD](https://doi.org/10.1145/3450626.3459767) narrow phase kernels, a form of conservative advancement that robustly supports large thickness/gaps. The CCD test can be pre-filtered and replaced using (optional) custom functions via callbacks:
 
 ```cpp
-tree.filter_pair = [&](const Eigen::Vector4i &sten, bool is_vf)->bool
-{
+tree.filter_pair = [&](const Eigen::Vector4i &sten, bool is_vf)->bool {
     // Return true to skip CCD test
     return my_skip_narrow_phase_test(...);
 };
-tree.narrow_phase = [&](const Eigen::Vector4i &sten, bool is_vf)->double
-{
+tree.narrow_phase = [&](const Eigen::Vector4i &sten, bool is_vf)->double {
     // Use custom narrow phase kernels to compute time of impact (toi)
     // and return toi if intersected, otherwise return < 0.
     return my_narrow_phase_test(...);
@@ -52,4 +52,26 @@ tree.narrow_phase = [&](const Eigen::Vector4i &sten, bool is_vf)->double
 
 ### General BVH Traversal
 
-Apart from continuous and discrete collision detections, traversers can be used to walk down the BVH. Two functions need to be implemented in the derived class to determine if the branch should be traversed (intersectVolume) and to process the leaf (intersectObject). See [test/traverser.cpp](test/traverser.cpp) for an example.
+Apart from continuous and discrete collision detections, traversers can be used to walk down the BVH. Two functions need to be implemented in the derived class to determine if the branch should be traversed (intersectVolume) and to process the leaf (intersectObject). See [test/traverser.cpp](test/traverser.cpp) for a complete example.
+
+```cpp
+class PointInTriangle : public mcl::ccd::BVHTraverse<double,2> {
+public:
+    using mcl::ccd::BVHTraverse<double,2>::VolumeType;
+    using mcl::ccd::BVHTraverse<double,2>::ObjectType;
+    Eigen::Vector2d point;
+    std::vector<Triangle> triangles;
+    int hit_triangle = -1;
+    bool intersectVolume(const VolumeType &v) {
+        return v.contains(point);
+    }
+    bool intersectObject(const ObjectType &o) {
+        const Triangle &tri = triangles[o.idx];
+        if (tri.contains_point(pt)) {
+            hit_triangle = o.idx;
+            return true;
+        }
+        return false; // return true to stop traversing
+    }
+};
+```

--- a/src/MCL/BVHTree.cpp
+++ b/src/MCL/BVHTree.cpp
@@ -45,11 +45,81 @@ void get_vertex(int vert_index, const T* V, Eigen::MatrixBase<DerivedV> &vert)
     }
 }
 
+template <int PDIM>
+bool prims_share_vertex(const int *p0, const int *p1)
+{
+    if (p0[0] == p1[0]) {
+        return true;
+    }
+    if constexpr (PDIM > 1)
+    {
+        if (p0[0] == p1[1] ||
+            p0[1] == p1[1] ||
+            p0[1] == p1[0]) {
+                return true;
+        }
+    }
+    if constexpr (PDIM > 2)
+    {
+        if (p0[0] == p1[2] ||
+            p0[1] == p1[2] ||
+            p0[2] == p1[0] ||
+            p0[2] == p1[1] ||
+            p0[2] == p1[2]) {
+            return true;
+        }
+    }
+    if constexpr (PDIM > 3)
+    {
+        if (p0[0] == p1[3] ||
+            p0[1] == p1[3] ||
+            p0[2] == p1[3] ||
+            p0[3] == p1[3] ||
+            p0[3] == p1[0] ||
+            p0[3] == p1[1] ||
+            p0[3] == p1[2]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <int PDIM>
+bool vertex_prim_share_vertex(int vi, const int *p)
+{
+    if (vi == p[0]) {
+        return true;
+    }
+    if constexpr (PDIM > 1)
+    {
+        if (vi == p[1]) {
+            return true;
+        }
+    }
+    if constexpr (PDIM > 2)
+    {
+        if (vi == p[2]) {
+            return true;
+        }
+    }
+    if constexpr (PDIM > 3)
+    {
+        if (vi == p[3]) {
+            return true;
+        }
+    }
+    return false;
+}
+
 template <typename T, int DIM, int PDIM>
 BVHTree<T,DIM,PDIM>::BVHTree()
 {
-    tree = std::make_shared<Eigen::KdBVH<T,DIM,LeafType> >();
+    tree = std::make_unique<Eigen::KdBVH<T,DIM,LeafType> >();
 }
+
+template <typename T, int DIM, int PDIM>
+BVHTree<T,DIM,PDIM>::~BVHTree() = default;
+
 
 template <typename T, int DIM, int PDIM>
 void BVHTree<T,DIM,PDIM>::update(const T* V0, const T* V1, const int *P, int np, const int *active)
@@ -57,7 +127,7 @@ void BVHTree<T,DIM,PDIM>::update(const T* V0, const T* V1, const int *P, int np,
     if (np == 0)
     {
         leaves.clear();
-        tree = std::make_shared<Eigen::KdBVH<T,DIM,LeafType> >();
+        tree = std::make_unique<Eigen::KdBVH<T,DIM,LeafType> >();
         return;
     }
 
@@ -161,16 +231,19 @@ void BVHTree<T,DIM,PDIM>::update(const T* V0, const T* V1, const int *P, int np,
 template <typename T, int DIM, int PDIM>
 void BVHTree<T,DIM,PDIM>::traverse(const T* V0, const T* V1, const int *P) const
 {
-    if (leaves.size() <= 1)
+    if (leaves.size() <= 1) {
         return;
+    }
 
     // Create a list of initial BVH intersection lists
     std::vector<std::pair<NodeIndex,NodeIndex> > queue;
     queue.reserve(leaves.size());
     make_frontlist(std::make_pair(tree->getRootIndex(), false), queue);
-    assert((int)queue.size() > 0);
-    std::atomic<int> stop(0);
+    if (queue.size() == 0) {
+        return;
+    }
 
+    std::atomic<int> stop(0);
     int nq = queue.size();
     if (options.parallel)
     {
@@ -202,14 +275,20 @@ template <typename T, int DIM, int PDIM>
 void BVHTree<T,DIM,PDIM>::make_frontlist(const NodeIndex &idx,
     std::vector<std::pair<NodeIndex,NodeIndex> > &queue) const
 {
-    if (idx.second) // is leaf node
+    if (idx.second) { // is leaf node
         return;
+    }
 
     NodeIndex l, r;
     get_children(idx, l, r);
-    assert(l.first >= 0 && r.first >= 0);
-    make_frontlist(l, queue);
-    make_frontlist(r, queue);
+
+    if (l.first >= 0) {
+        make_frontlist(l, queue);
+    }
+
+    if (r.first >= 0) {
+        make_frontlist(r, queue);
+    }
 
     // if both leaf, should not have same idx
     assert((l.second==r.second) ? (l.first!=r.first) : true);
@@ -235,21 +314,21 @@ void BVHTree<T,DIM,PDIM>::get_children(const NodeIndex &idx, NodeIndex &l, NodeI
     VolumeIter vBegin = nullptr, vEnd = nullptr;
     ObjectIter oBegin = nullptr, oEnd = nullptr;
     tree->getChildren(idx.first, vBegin, vEnd, oBegin, oEnd);
-    int num_children = 0;
+    //int num_children = 0;
     bool is_l = true;
     for (; vBegin != vEnd; ++vBegin)
     {
         if (is_l) { l = NodeIndex(*vBegin, false); is_l = false; }
         else { r = NodeIndex(*vBegin, false); }
-        num_children++;
+        //num_children++;
     }
     for (; oBegin != oEnd; ++oBegin)
     {
         if (is_l) { l = NodeIndex(oBegin->idx, true); is_l = false; }
         else { r = NodeIndex(oBegin->idx, true); }
-        num_children++;
+        //num_children++;
     }
-    assert(num_children == 2); // assumes binary tree
+    //assert(num_children == 2); // assumes binary tree
 }
 
 template <typename T, int DIM, int PDIM>
@@ -272,8 +351,8 @@ void BVHTree<T,DIM,PDIM>::collide(
     }
 
     // if both leaf, not eq
-    assert(left.first >= 0 && right.first >= 0);
-    assert((left.second == right.second) ? (left.first != right.first) : true);
+    //assert(left.first >= 0 && right.first >= 0);
+    //assert((left.second == right.second) ? (left.first != right.first) : true);
 
     // Check if nodes intersect or inactive
     if (!boxes_intersect(left,right)) {
@@ -352,15 +431,6 @@ void BVHTree<T,DIM,PDIM>::get_candidates(int p0, int p1, const int *P,
     get_primitive<PDIM>(p0, P, f0);
     get_primitive<PDIM>(p1, P, f1);
 
-    auto vf_shared_vertex = [](int vi, const int *fi)->bool
-    {
-        for (int i=0; i<PDIM; ++i)
-            if (vi == fi[i])
-                return true;
-
-        return false;
-    };
-
     int pair_index = 0;
 
     // VF, f0 -> f1
@@ -372,7 +442,7 @@ void BVHTree<T,DIM,PDIM>::get_candidates(int p0, int p1, const int *P,
             continue;
         }
 
-        if (vf_shared_vertex(f0[i], f1))
+        if (vertex_prim_share_vertex<PDIM>(f0[i], f1))
         {
             pairs[pair_index++].second = -1;
             continue;
@@ -400,7 +470,7 @@ void BVHTree<T,DIM,PDIM>::get_candidates(int p0, int p1, const int *P,
             continue;
         }
 
-        if (vf_shared_vertex(f1[i], f0))
+        if (vertex_prim_share_vertex<PDIM>(f1[i], f0))
         {
             pairs[pair_index++].second = -1;
             continue;
@@ -525,11 +595,9 @@ T BVHTree<T,DIM,PDIM>::default_narrow_phase(const T* V0, const T* V1, const Eige
 template <typename T, int DIM, int PDIM>
 bool BVHTree<T,DIM,PDIM>::default_discrete_test(const T* V, const int *p0, const int *p1) const
 {
-    // Shares vertex?
-    for (int i=0; i<PDIM; ++i)
-        for (int j=0; j<PDIM; ++j)
-            if (p0[i] == p1[j])
-                return false;
+    if (prims_share_vertex<PDIM>(p0, p1)) {
+        return false;
+    }
 
     if constexpr (DIM == 3 && PDIM == 3)
     {
@@ -551,19 +619,19 @@ bool BVHTree<T,DIM,PDIM>::default_discrete_test(const T* V, const int *p0, const
         get_vertex(p1[1], V, v1[1]);
         return NarrowPhase<T,2>::discrete_edge_edge(v0, v1); 
     }
-    else if (DIM == 2 && PDIM == 3)
+    else if constexpr (DIM == 2 && PDIM == 3)
     {
         // 2D two triangles = 6 edge-edge tests
-        for (int p0_i=0; p0_i<3; ++p0_i)
+        Eigen::Vector2<T> v0[2];
+        Eigen::Vector2<T> v1[2];
+        for (int i=0; i<3; ++i)
         {
-            Eigen::Vector2<T> v0[2];
-            get_vertex(p0[0], V, v0[0]);
-            get_vertex(p0[1], V, v0[1]);
-            for (int p1_i=0; p1_i<3; ++p1_i)
+            get_vertex(p0[i], V, v0[0]);
+            get_vertex(p0[(i+1)%3], V, v0[1]);
+            for (int j=0; j<3; ++j)
             {
-                Eigen::Vector2<T> v1[2];
-                get_vertex(p1[0], V, v1[0]);
-                get_vertex(p1[1], V, v1[1]);
+                get_vertex(p1[j], V, v1[0]);
+                get_vertex(p1[(j+1)%3], V, v1[1]);
                 if (NarrowPhase<T,2>::discrete_edge_edge(v0, v1)) {
                     return true;
                 }

--- a/src/MCL/BVHTree.cpp
+++ b/src/MCL/BVHTree.cpp
@@ -19,6 +19,32 @@ namespace mcl
 namespace ccd
 {
 
+template <int PDIM>
+void get_primitive(int prim_index, const int *P, int prim[PDIM])
+{
+    prim[0] = P[prim_index*PDIM + 0];
+    if constexpr (PDIM > 1) {
+        prim[1] = P[prim_index*PDIM + 1];
+    }
+    if constexpr (PDIM > 2) {
+        prim[2] = P[prim_index*PDIM + 2];
+    }
+    if constexpr (PDIM > 3) {
+        prim[3] = P[prim_index*PDIM + 3];
+    }
+}
+
+template <typename T, typename DerivedV>
+void get_vertex(int vert_index, const T* V, Eigen::MatrixBase<DerivedV> &vert)
+{
+    constexpr int DIM = Eigen::MatrixBase<DerivedV>::SizeAtCompileTime;
+    vert[0] = V[vert_index*DIM + 0];
+    vert[1] = V[vert_index*DIM + 1];
+    if constexpr (DIM > 2) {
+        vert[2] = V[vert_index*DIM + 2];
+    }
+}
+
 template <typename T, int DIM, int PDIM>
 BVHTree<T,DIM,PDIM>::BVHTree()
 {
@@ -67,10 +93,14 @@ void BVHTree<T,DIM,PDIM>::update(const T* V0, const T* V1, const int *P, int np,
                 int vi = P[i*PDIM+j];
                 bool v_not_seen = seen_verts.emplace(vi).second;
                 if (v_not_seen)
+                {
                     leaf.v[j]=1;
+                }
 
                 if (PDIM != 3)
+                {
                     continue;
+                }
 
                 int e0 = vi;
                 int e1 = P[i*PDIM+((j+1)%3)];
@@ -78,7 +108,9 @@ void BVHTree<T,DIM,PDIM>::update(const T* V0, const T* V1, const int *P, int np,
                 std::string h = std::to_string(e0)+' '+std::to_string(e1);
                 bool e_not_seen = seen_edges.emplace(h).second;
                 if (e_not_seen)
+                {
                     leaf.e[j]=1;
+                }
             }
         }
     }
@@ -101,11 +133,8 @@ void BVHTree<T,DIM,PDIM>::update(const T* V0, const T* V1, const int *P, int np,
             int vi = P[i*PDIM + j];
             VecType xi_t0 = VecType::Zero();
             VecType xi_t1 = VecType::Zero();
-            for (int k=0; k<DIM; ++k)
-            {
-                xi_t0[k] = V0[vi*DIM+k];
-                xi_t1[k] = V1[vi*DIM+k];
-            }
+            get_vertex(vi, V0, xi_t0);
+            get_vertex(vi, V1, xi_t1);
             leaf.box.t0.extend(xi_t0);
             leaf.box.t1.extend(xi_t1);
             leaf.box.extend(xi_t0);
@@ -277,11 +306,8 @@ void BVHTree<T,DIM,PDIM>::collide(
         if (options.discrete)
         {
             int p0[PDIM], p1[PDIM];
-            for (int i=0; i<PDIM; ++i)
-            {
-                p0[i] = P[left.first*PDIM+i];
-                p1[i] = P[right.first*PDIM+i];
-            }
+            get_primitive<PDIM>(left.first, P, p0);
+            get_primitive<PDIM>(right.first, P, p1);
             bool d_hit = default_discrete_test(V1, p0, p1);
             if (d_hit && append_discrete != nullptr)
             {
@@ -323,11 +349,8 @@ void BVHTree<T,DIM,PDIM>::get_candidates(int p0, int p1, const int *P,
     }
 
     int f0[PDIM], f1[PDIM];
-    for (int i=0; i<PDIM; ++i)
-    {
-        f0[i] = P[p0*PDIM+i];
-        f1[i] = P[p1*PDIM+i];
-    }
+    get_primitive<PDIM>(p0, P, f0);
+    get_primitive<PDIM>(p1, P, f1);
 
     auto vf_shared_vertex = [](int vi, const int *fi)->bool
     {
@@ -398,7 +421,9 @@ void BVHTree<T,DIM,PDIM>::get_candidates(int p0, int p1, const int *P,
 
     // Skip edge-edge if not in 3D
     if (DIM != 3)
+    {
         return;
+    }
 
     // EE
     for (int i=0; i<3; ++i)
@@ -440,16 +465,22 @@ bool BVHTree<T,DIM,PDIM>::boxes_intersect(const NodeIndex &left, const NodeIndex
     const typename BVHLeaf<T,DIM>::BoxType &rbox = get_box(right);
 
     // Check if both branches inactive
-    if (!lbox.active && !rbox.active)
+    if (!lbox.active && !rbox.active) {
         return false;
+    }
 
     // Check nodes intersect
-    if (!lbox.intersects(rbox))
+    if (!lbox.intersects(rbox)) {
         return false;
+    }
 
     // Check time varying boxes if not empty
-    if (lbox.t0.isEmpty() || rbox.t0.isEmpty()) { return true; }
-    if (lbox.t1.isEmpty() || rbox.t1.isEmpty()) { return true; }
+    if (lbox.t0.isEmpty() || rbox.t0.isEmpty()) {
+        return true;
+    }
+    if (lbox.t1.isEmpty() || rbox.t1.isEmpty()) {
+        return true;
+    }
 
     for (int i=0; i<DIM; ++i)
     {
@@ -468,31 +499,25 @@ T BVHTree<T,DIM,PDIM>::default_narrow_phase(const T* V0, const T* V1, const Eige
     VecType verts0[PDIM+1], verts1[PDIM+1];
     for (int i=0; i<PDIM+1; ++i)
     {
-        if (sten[i] < 0)
-        {
+        if (sten[i] < 0) {
             return -2; // error
         }
-
-        for (int j=0; j<DIM; ++j)
-        {
-            verts0[i][j] = V0[sten[i]*DIM+j];
-            verts1[i][j] = V1[sten[i]*DIM+j];
-        }
+        get_vertex(sten[i], V0, verts0[i]);
+        get_vertex(sten[i], V1, verts1[i]);
     }
 
     T toi = -1;
     int hit = 0;
-    if (is_vf)
-    {
+    if (is_vf) {
         hit = NarrowPhaseACCD<T,DIM>::query_ccd_vf(verts0, verts1, options.vf_ccd_eta, toi);
     }
-    else
-    {
+    else {
         hit = NarrowPhaseACCD<T,DIM>::query_ccd_ee(verts0, verts1, options.ee_ccd_eta, toi);
     }
 
-    if (hit == 1)
+    if (hit == 1) {
         return toi;
+    }
 
     return -1;
 }
@@ -506,51 +531,39 @@ bool BVHTree<T,DIM,PDIM>::default_discrete_test(const T* V, const int *p0, const
             if (p0[i] == p1[j])
                 return false;
 
-    if (DIM == 3 && PDIM == 3)
+    if constexpr (DIM == 3 && PDIM == 3)
     {
         Eigen::Vector3<T> v0[3], v1[3];
-        for (int i=0; i<3; ++i)
-        {
-            for (int j=0; j<3; ++j)
-            {
-                v0[i][j] = V[p0[i]*3+j];
-                v1[i][j] = V[p1[i]*3+j];
-            }
-        }
+        get_vertex(p0[0], V, v0[0]);
+        get_vertex(p0[1], V, v0[1]);
+        get_vertex(p0[2], V, v0[2]);
+        get_vertex(p1[0], V, v1[0]);
+        get_vertex(p1[1], V, v1[1]);
+        get_vertex(p1[2], V, v1[2]);
         return NarrowPhase<T,3>::discrete_tri_tri(v0, v1);
     }
-    else if (DIM == 2 && PDIM == 2)
+    else if constexpr (DIM == 2 && PDIM == 2)
     {
         Eigen::Vector2<T> v0[2], v1[2];
-        for (int i=0; i<2; ++i)
-        {
-            for (int j=0; j<2; ++j)
-            {
-                v0[i][j] = V[p0[i]*2+j];
-                v1[i][j] = V[p1[i]*2+j];
-            }
-        }
+        get_vertex(p0[0], V, v0[0]);
+        get_vertex(p0[1], V, v0[1]);
+        get_vertex(p1[0], V, v1[0]);
+        get_vertex(p1[1], V, v1[1]);
         return NarrowPhase<T,2>::discrete_edge_edge(v0, v1); 
     }
     else if (DIM == 2 && PDIM == 3)
     {
-        // two triangles = 6 edge-edge tests
+        // 2D two triangles = 6 edge-edge tests
         for (int p0_i=0; p0_i<3; ++p0_i)
         {
             Eigen::Vector2<T> v0[2];
-            v0[0][0] = V[p0[p0_i]*2+0];
-            v0[0][1] = V[p0[p0_i]*2+1];
-            v0[1][0] = V[p0[(p0_i+1)%3]*2+0];
-            v0[1][1] = V[p0[(p0_i+1)%3]*2+1];
-
+            get_vertex(p0[0], V, v0[0]);
+            get_vertex(p0[1], V, v0[1]);
             for (int p1_i=0; p1_i<3; ++p1_i)
             {
                 Eigen::Vector2<T> v1[2];
-                v1[0][0] = V[p1[p1_i]*2+0];
-                v1[0][1] = V[p1[p1_i]*2+1];
-                v1[1][0] = V[p1[(p1_i+1)%3]*2+0];
-                v1[1][1] = V[p1[(p1_i+1)%3]*2+1];
-
+                get_vertex(p1[0], V, v1[0]);
+                get_vertex(p1[1], V, v1[1]);
                 if (NarrowPhase<T,2>::discrete_edge_edge(v0, v1)) {
                     return true;
                 }

--- a/src/MCL/BVHTree.hpp
+++ b/src/MCL/BVHTree.hpp
@@ -43,7 +43,7 @@ public:
     static const size_t NumCandidates = DIM == 2 ? 6 : 15; // narrowphase candidates
 
     std::vector<LeafType> leaves;
-    std::shared_ptr<Eigen::KdBVH<T,DIM,LeafType> > tree;
+    std::unique_ptr<Eigen::KdBVH<T,DIM,LeafType>> tree;
 
     struct Options
     {
@@ -62,7 +62,7 @@ public:
     } options;
 
     BVHTree();
-    virtual ~BVHTree() {}
+    virtual ~BVHTree();
 
     // V is n x dim with V0 at t=0 and V1 at t=1.
     // P can be m x 3 or 4, depending on the prim (tri or tet)

--- a/src/MCL/NarrowPhase.cpp
+++ b/src/MCL/NarrowPhase.cpp
@@ -645,7 +645,6 @@ bool NarrowPhaseACCD<T,DIM>::additive_ccd(
     T s = 1; // scaling factor
     T xsi = eta; // minimal sep
     T t_c = 1; // global min t (for line search)
-    assert((!is_vf && ns==4) || is_vf);
 
     // Displacement vectors and current x
     VecType p[ns];
@@ -709,7 +708,6 @@ bool NarrowPhaseACCD<T,DIM>::additive_ccd(
         t_l = 0.9 * (d*d - xsi*xsi) / ((d + xsi)*l_p);
     }
 
-    assert(iter < max_iter);
     return true;
 }
 
@@ -720,11 +718,9 @@ T NarrowPhaseACCD<T,DIM>::pair_distance(
 {
     using Vec3 = Eigen::Matrix<T,3,1>;
     using Vec2 = Eigen::Matrix<T,2,1>;
-    assert(DIM==2 || DIM==3);
 
     if (DIM==2)
     {
-        assert(is_vf);
         Vec2 v0 = v[0].template head<2>();
         Vec2 v1 = v[1].template head<2>();
         Vec2 v2 = v[2].template head<2>();

--- a/test/test_2D.cpp
+++ b/test/test_2D.cpp
@@ -40,7 +40,7 @@ int main(int, char**)
         };
         tree.traverse(V, V, F);
 
-        assert_true(pairs.size() == 1, "didn't detect single intersection");
+        assert_true(pairs.size() == 1, "didn't detect single intersection: "+std::to_string(pairs.size()));
         assert_true(pairs[0][0] == 1 && pairs[0][1] == 0, "bad intersection prim idx");
     }
 


### PR DESCRIPTION
- Unrolled some loops and using "if constexpr" instead which is a bit more efficient in kernel functions.
- Changed tree shared_ptr to unique_ptr to prevent accidental copy (and modification of shared underlying tree). Will add explicit copy constructor in future as needed.